### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,13 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+  
+  def show
+    @item =Item.find(params[:id])
+  end
+
+
+
 end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,13 +17,10 @@ class ItemsController < ApplicationController
       render :new
     end
   end
-  
+
   def show
-    @item =Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
-
-
-
 end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -158,7 +158,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @items[0] == nil %>
+      <% if @items.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,11 +125,9 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', items_path, class: "subtitle" %>    
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -144,7 +142,7 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,10 +152,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% if @items.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -177,8 +171,6 @@
         <% end %>
       <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name%>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,55 +16,54 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%=  number_to_currency(@item.price, unit: "￥", strip_insignificant_zeros: true) %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.postage.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+   <% if user_signed_in?  && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+   <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+   <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.concept %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nick_name%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name%></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.region.name%></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
+          <td class="detail-value"><%= @item.shipping.name %></td>
+        </tr> 
       </tbody>
     </table>
     <div class="option">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
        <p class='or-text'>or</p>
        <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-     <% elsif %>
+     <% else %>
      <%# 商品が売れていない場合はこちらを表示しましょう %>
        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
      <%# //商品が売れていない場合はこちらを表示しましょう %>
@@ -103,7 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,14 +24,16 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-   <% if user_signed_in?  && current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-   <% elsif user_signed_in? %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+   <% if user_signed_in? %>
+     <% if current_user.id == @item.user_id %>
+       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+       <p class='or-text'>or</p>
+       <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+     <% elsif %>
+     <%# 商品が売れていない場合はこちらを表示しましょう %>
+       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+     <%# //商品が売れていない場合はこちらを表示しましょう %>
+     <% end %>
    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :index]
+  resources :items, only: [:new, :create, :index, :show, :destroy]
 end


### PR DESCRIPTION
＃What
商品詳細情報の表示
ボタンの表示切り替え
→出品者には編集・削除ボタンが表示され購入ボタンは表示されない。
→出品者以外のログインしているユーザーは購入ボタンが表示される。
→ログインしていないユーザーには商品の詳細表示までで購入ボタンは表示されない。

＃Why
商品毎の詳細ページを表示させるため

＜確認用GIF＞
商品出品時に登録した情報が見られるようになっていること
ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://i.gyazo.com/e2536fe1c91ffa8048d59c74ed975e6d.gif

ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/bcc4377cbd2e0eb9f59bc1d2afe14d05

ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://i.gyazo.com/144673471c39f04a7332046f7703916b.gif